### PR TITLE
Add grace time for updating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "laravel/framework": "^5.6|^6.0|^7.0"
+        "laravel/framework": "^5.6|^6|^7|^8"
     },
     "autoload": {
         "psr-4": {

--- a/src/Http/Middleware/LastActivity.php
+++ b/src/Http/Middleware/LastActivity.php
@@ -35,12 +35,12 @@ class LastActivity
      *
      * @param Model $user
      */
-    private function updateLastActivityField(Model $user)
+    protected function updateLastActivityField(Model $user)
     {
         $lastActivityField = config('last-activity.field');
         $graceTime = config('last-activity.grace_time');
 
-        if ($graceTime > 0 && ($user->$lastActivityField)->addSeconds($graceTime) > now()) {
+        if ($graceTime > 0 && $user->$lastActivityField && ($user->$lastActivityField)->addSeconds($graceTime) > now()) {
             return;
         }
 
@@ -58,7 +58,7 @@ class LastActivity
      * @param callable $callback
      * @return mixed
      */
-    private function hideFromEvents(Model $model, callable $callback)
+    protected function hideFromEvents(Model $model, callable $callback)
     {
         $dispatcher = $model::getEventDispatcher();
         $model::unsetEventDispatcher();

--- a/src/Http/Middleware/LastActivity.php
+++ b/src/Http/Middleware/LastActivity.php
@@ -38,6 +38,11 @@ class LastActivity
     private function updateLastActivityField(Model $user)
     {
         $lastActivityField = config('last-activity.field');
+        $graceTime = config('last-activity.grace_time');
+
+        if ($graceTime > 0 && ($user->$lastActivityField)->addSeconds($graceTime) > now()) {
+            return;
+        }
 
         $this->hideFromEvents($user, function() use ($user, $lastActivityField) {
             $user->$lastActivityField = now();

--- a/src/config/last-activity.php
+++ b/src/config/last-activity.php
@@ -5,4 +5,10 @@ return [
     // Field in which the last activity date time will be stored.
     'field' => 'last_activity',
 
+    /**
+     * The amount of seconds the field is considered stale and should update.
+     * This prevents a write on every request, particularly useful with read replica databases.
+     * Set to 0 to disable.
+     */
+    'grace_time' => 0,
 ];


### PR DESCRIPTION
This PR adds a config variable that sets the amount of seconds the update time is considered stale and needs updating.

This is useful when using sticky read replicas, as the only write query for a request is the to update `last_activity`.

I've also set the internal functions to `protected` so they are easily overridden.

