### PR TITLE
Support Laravel 9 [new major version required]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ project.
 composer require divineomega/laravel-last-activity
 ```
 
+If you are using Laravel < 8.0 or PHP < 8.0 use version 1.3.0.
+
+```bash
+composer require divineomega/laravel-last-activity:"^1.3.0"
+```
+
 ## Setup
 
 This package requires you to register middleware within 

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,13 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "laravel/framework": "^5.6|^6|^7|^8"
+        "php": "^8.0",
+        "laravel/framework": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {
             "DivineOmega\\LaravelLastActivity\\": "src/"
         }
-    },
-    "require-dev": {
-        "orchestra/testbench": "^3.8"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.0|^9.0"
+        "laravel/framework": ">=8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* Laravel 9 requires PHP 8 or above so it's time for a major version bump for this package
* I have added info on using anything less than Laravel 8 or PHP 8 in the README